### PR TITLE
Guard against upgrade path problems when coming from 8.1

### DIFF
--- a/block_access.module
+++ b/block_access.module
@@ -23,7 +23,7 @@ function block_access_entity_access(EntityInterface $entity, $operation, Account
   return AccessResult::allowedIfHasPermission($account, $any)
     ->orIf(
       AccessResult::allowedIfHasPermission($account, $own)
-      ->andIf(AccessResult::allowedIf($entity instanceof RevisionLogInterface && $entity->getRevisionUser()->id() === $account->id()))
+      ->andIf(AccessResult::allowedIf($entity instanceof RevisionLogInterface && $entity->getRevisionUser() && $entity->getRevisionUser()->id() === $account->id()))
       ->addCacheableDependency($entity)
     );
 }


### PR DESCRIPTION
When upgrading from 8.1, all blocks had a null revision_user field so it made editing those blocks to give them one not possible.