### PR TITLE
Do not require administer blocks permission to access creation form

### DIFF
--- a/block_access.services.yml
+++ b/block_access.services.yml
@@ -1,0 +1,9 @@
+services:
+  block_access.route_subscriber:
+    class: Drupal\block_access\Routing\RouteSubscriber
+    tags:
+      - { name: event_subscriber }
+  block_access.access_check:
+    class: Drupal\block_access\Access\CreateBlockContentTypeCheck
+    tags:
+      - { name: access_check, applies_to: _block_content_access_create }

--- a/src/Access/CreateBlockContentTypeCheck.php
+++ b/src/Access/CreateBlockContentTypeCheck.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Drupal\block_access\Access;
+
+use Drupal\block_content\BlockContentTypeInterface;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Routing\Access\AccessInterface;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Access control for creation of specific types of block content.
+ */
+class CreateBlockContentTypeCheck implements AccessInterface {
+
+  /**
+   * Determine if a user is allowed to create a specific type of block content.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user attempting to create the content.
+   * @param \Drupal\block_content\BlockContentTypeInterface $block_content_type
+   *   The type of block content to be created.
+   *
+   * @return \Drupal\Core\Access\AccessResult
+   *   Whether the user is allowed to create the content.
+   */
+  public function access(AccountInterface $account, BlockContentTypeInterface $block_content_type) {
+    return AccessResult::allowedIfHasPermissions(
+      $account,
+      [
+        // Default permission to manage all block content types.
+        'administer blocks',
+        // This is the new per content type permission we have added.
+        sprintf('create %s block_content', $block_content_type->id())
+      ],
+      'OR'
+    );
+  }
+}

--- a/src/Routing/RouteSubscriber.php
+++ b/src/Routing/RouteSubscriber.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\block_access\Routing\RouteSubscriber.
+ */
+
+namespace Drupal\block_access\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Listens to the dynamic route events.
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterRoutes(RouteCollection $collection) {
+    // Replace the default permission check for "administer blocks" with our
+    // own which will also support permissions to create individual types of
+    // block content.
+    if ($route = $collection->get('block_content.add_form')) {
+      $requirements = $route->getRequirements();
+      unset($requirements['_permission']);
+      $requirements['_block_content_access_create'] = 'true';
+      $route->setRequirements($requirements);
+    }
+  }
+}


### PR DESCRIPTION
The current version of implements hook_entity_create_access to allow
users to create specific types of block content. However the route to
the block content creation form still requires the “administer blocks”
permission. Adding this permission seems to go against the entire 
purpose of this module as it will grant access to all block content
types anyhow.

This is an attempt at fixing this by changing the access control for 
the block content create form route to allow either “administer blocks”
or the new per block content type permissions.